### PR TITLE
Fixes #9: parse utf8 symbols that occupy more than one column correctly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/github.com/mattn/go-runewidth"]
 	path = vendor/github.com/mattn/go-runewidth
-	url = ssh://github.com/mattn/go-runewidth
+	url = https://github.com/mattn/go-runewidth

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/github.com/mattn/go-runewidth"]
+	path = vendor/github.com/mattn/go-runewidth
+	url = ssh://github.com/mattn/go-runewidth

--- a/table.go
+++ b/table.go
@@ -29,7 +29,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
+
+	runewidth "github.com/mattn/go-runewidth"
 )
 
 var (
@@ -213,14 +216,14 @@ func (t *table) calculateWidths() {
 	t.widths = make([]int, len(t.header))
 	for _, row := range t.rows {
 		for i, v := range row {
-			if w := len(v) + t.Padding; w > t.widths[i] {
+			if w := displayWidth(v) + t.Padding; w > t.widths[i] {
 				t.widths[i] = w
 			}
 		}
 	}
 
 	for i, v := range t.header {
-		if w := len(v) + t.Padding; w > t.widths[i] {
+		if w := displayWidth(v) + t.Padding; w > t.widths[i] {
 			t.widths[i] = w
 		}
 	}
@@ -235,9 +238,16 @@ func applyWidths(row []string, widths []int) []interface{} {
 }
 
 func lenOffset(s string, w int) string {
-	l := w - len(s)
+	l := w - displayWidth(s)
 	if l <= 0 {
 		return ""
 	}
 	return strings.Repeat(" ", l)
+}
+
+var ansi = regexp.MustCompile("\033\\[(?:[0-9]{1,3}(?:;[0-9]{1,3})*)?[m|K]")
+
+// return the width as displayed, ignoring ansi codes
+func displayWidth(str string) int {
+	return runewidth.StringWidth(ansi.ReplaceAllLiteralString(str, ""))
 }

--- a/table_test.go
+++ b/table_test.go
@@ -122,6 +122,17 @@ func TestTable_WithWriter(t *testing.T) {
 	assert.NotEmpty(t, out)
 }
 
+func TestTable_handlesUTF8(t *testing.T) {
+	buf := bytes.Buffer{}
+	tbl := New("header1", "header2").WithWriter(&buf).WithPadding(2)
+	tbl.AddRow("fizz", "buzz")
+	tbl.AddRow("求z", "buzz")
+	tbl.Print()
+	out := buf.String()
+
+	assert.Contains(t, out, "求z      buzz")
+}
+
 func TestTable_AddRow(t *testing.T) {
 	buf := bytes.Buffer{}
 	tbl := New("foo", "bar").WithWriter(&buf).AddRow("fizz", "buzz")


### PR DESCRIPTION
Needs now an additional non standard package from mattn/go-runewidth