### PR TITLE
Fixes #9 Fixes #10; Customize width calculation for the table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,10 @@
 sudo: false
 language: go
-go: 1.5
+go: 1.8
 
 branches:
   only:
     - master
 
-install:
-  - go get -t ./...
-  - go get -u github.com/golang/lint/golint
-
-script:
-  - gofmt -l .
-  - golint ./...
-  - go tool vet -test .
-  - go test -v -cover ./...
+install: go get -t ./... github.com/golang/lint/golint
+script: make lint test

--- a/makefile
+++ b/makefile
@@ -1,0 +1,9 @@
+.PHONY: lint
+lint:
+	gofmt -d -s .
+	golint -set_exit_status ./...
+	go tool vet -all -shadow -shadowstrict .
+
+.PHONY: test
+test:
+	go test -v -cover -race ./...

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ Package table provides a convenient way to generate tabular output of any data, 
 - The printed output can be sent to any `io.Writer`, defaulting to `os.Stdout`.
 - Built to an interface, so you can roll your own `Table` implementation.
 - Works well with ANSI colors ([fatih/color](https://github.com/fatih/color) in the example)!
+- Can provide a custom `WidthFunc` to accomodate multi- and zero-width characters (such as [runewidth](https://github.com/mattn/go-runewidth))
 
 ## Usage
 

--- a/table_test.go
+++ b/table_test.go
@@ -8,10 +8,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mattn/go-runewidth"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestFormatter(t *testing.T) {
+	t.Parallel()
+
 	var formatter Formatter
 
 	fn := func(a string, b ...interface{}) string { return "" }
@@ -21,6 +24,8 @@ func TestFormatter(t *testing.T) {
 }
 
 func TestTable_New(t *testing.T) {
+	t.Parallel()
+
 	buf := bytes.Buffer{}
 	New("foo", "bar").WithWriter(&buf).Print()
 	out := buf.String()
@@ -36,6 +41,8 @@ func TestTable_New(t *testing.T) {
 }
 
 func TestTable_WithHeaderFormatter(t *testing.T) {
+	t.Parallel()
+
 	uppercase := func(f string, v ...interface{}) string {
 		return strings.ToUpper(fmt.Sprintf(f, v...))
 	}
@@ -57,6 +64,8 @@ func TestTable_WithHeaderFormatter(t *testing.T) {
 }
 
 func TestTable_WithFirstColumnFormatter(t *testing.T) {
+	t.Parallel()
+
 	uppercase := func(f string, v ...interface{}) string {
 		return strings.ToUpper(fmt.Sprintf(f, v...))
 	}
@@ -81,6 +90,8 @@ func TestTable_WithFirstColumnFormatter(t *testing.T) {
 }
 
 func TestTable_WithPadding(t *testing.T) {
+	t.Parallel()
+
 	// zero value
 	buf := bytes.Buffer{}
 	tbl := New("foo", "bar").WithWriter(&buf).WithPadding(0)
@@ -102,6 +113,8 @@ func TestTable_WithPadding(t *testing.T) {
 }
 
 func TestTable_WithWriter(t *testing.T) {
+	t.Parallel()
+
 	// not that we haven't been using it in all these tests but:
 	buf := bytes.Buffer{}
 	New("foo", "bar").WithWriter(&buf).Print()
@@ -123,6 +136,8 @@ func TestTable_WithWriter(t *testing.T) {
 }
 
 func TestTable_AddRow(t *testing.T) {
+	t.Parallel()
+
 	buf := bytes.Buffer{}
 	tbl := New("foo", "bar").WithWriter(&buf).AddRow("fizz", "buzz")
 	tbl.Print()
@@ -145,4 +160,22 @@ func TestTable_AddRow(t *testing.T) {
 	buf.Reset()
 	tbl.AddRow("bippity", "boppity", "boo").Print()
 	assert.NotContains(t, buf.String(), "boo")
+}
+
+func TestTable_WithWidthFunc(t *testing.T) {
+	t.Parallel()
+
+	buf := bytes.Buffer{}
+
+	New("", "").
+		WithWriter(&buf).
+		WithPadding(1).
+		WithWidthFunc(runewidth.StringWidth).
+		AddRow("请求", "alpha").
+		AddRow("abc", "beta").
+		Print()
+
+	actual := buf.String()
+	assert.Contains(t, actual, "请求 alpha")
+	assert.Contains(t, actual, "abc  beta")
 }


### PR DESCRIPTION
This patch adds the ability to provide a custom WidthFunc to change the behavior of how width's are calculated for the string, defaulting to `encoding/utf8.RuneCountInString`. 

Understandably, not all characters are single-byte, so using `len` as before was erroneous. Similarly, not all runes are single-width, such as emoji and CJK characters. However, vendoring in an external library for this purpose seemed heavy handed and would be the first non-test dependency to be required by this package. 

The compromise then is to add the ability to override how widths are calculated. If tables are being created in multiple locations in the codebase, the `DefaultWidthFunc` can/should be overridden.

/cc @brunnre8
Fixes #9 | Fixes #10