### PR TITLE
Add support for values that contain newlines + add tests that cover the full table output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/rodaine/table
 go 1.14
 
 require (
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/mattn/go-runewidth v0.0.9
 	github.com/stretchr/testify v1.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/table.go
+++ b/table.go
@@ -192,14 +192,21 @@ func (t *table) WithWidthFunc(f WidthFunc) Table {
 }
 
 func (t *table) AddRow(vals ...interface{}) Table {
-	row := make([]string, len(t.header))
-	for i, val := range vals {
-		if i >= len(t.header) {
-			break
-		}
-		row[i] = fmt.Sprint(val)
+	maxNumNewlines := 0
+	for _, val := range vals {
+		maxNumNewlines = max(strings.Count(fmt.Sprint(val), "\n"), maxNumNewlines)
 	}
-	t.rows = append(t.rows, row)
+	for i := 0; i <= maxNumNewlines; i++ {
+		row := make([]string, len(t.header))
+		for j, val := range vals {
+			if j >= len(t.header) {
+				break
+			}
+			v := strings.Split(fmt.Sprint(val), "\n")
+			row[j] = safeOffset(v, i)
+		}
+		t.rows = append(t.rows, row)
+	}
 
 	return t
 }
@@ -280,4 +287,18 @@ func (t *table) lenOffset(s string, w int) string {
 		return ""
 	}
 	return strings.Repeat(" ", l)
+}
+
+func max(i1, i2 int) int {
+	if i1 > i2 {
+		return i1
+	}
+	return i2
+}
+
+func safeOffset(sarr []string, idx int) string {
+	if idx >= len(sarr) {
+		return ""
+	}
+	return sarr[idx]
 }

--- a/table_test.go
+++ b/table_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/mattn/go-runewidth"
 	"github.com/stretchr/testify/assert"
 )
@@ -160,6 +161,59 @@ func TestTable_AddRow(t *testing.T) {
 	buf.Reset()
 	tbl.AddRow("bippity", "boppity", "boo").Print()
 	assert.NotContains(t, buf.String(), "boo")
+
+	// check the full table
+	buf.Reset()
+	tbl.Print()
+	expected := `foo      bar      
+fizz     buzz     
+                  
+cat               
+bippity  boppity  
+`
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Fatalf("table mismatch (-expected +got):\n%s\nout=%#v", diff, buf.String())
+	}
+}
+
+func TestTable_AddRow_WithNewLines(t *testing.T) {
+	t.Parallel()
+
+	buf := bytes.Buffer{}
+	tbl := New("foo", "bar").WithWriter(&buf).AddRow("fizz", "buzz")
+
+	// Add some rows
+	tbl.AddRow()
+	tbl.AddRow("cat")
+
+	// add an entry that contains new lines
+	tbl.AddRow("bippity", "boppity\nboop")
+
+	// Add a couple more rows
+	tbl.AddRow("a", "b")
+	tbl.AddRow("c", "d")
+
+	// and another entry with more new lines
+	tbl.AddRow("1\n2", "x\ny\nz")
+
+	// check the full table
+	buf.Reset()
+	tbl.Print()
+	expected := `foo      bar      
+fizz     buzz     
+                  
+cat               
+bippity  boppity  
+         boop     
+a        b        
+c        d        
+1        x        
+2        y        
+         z        
+`
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Fatalf("table mismatch (-expected +got):\n%s\nout=%#v", diff, buf.String())
+	}
 }
 
 func TestTable_SetRows(t *testing.T) {


### PR DESCRIPTION
Thank you for this library! I used it in [one of my projects](https://github.com/ddworken/hishtory) and it is super helpful. 

I recently realized that the behavior if someone does `tbl.AddRow("foo\nbar")` is slightly non-optimal. Currently, it has no special handling for this and thus the table formatting gets messed up. 

With this PR, it will instead display it correctly spread across multiple rows. For example, here's a table rendered with "foo" and "bar" as the headers and with the single call `tbl.AddRow("1\n2", "x\ny\nz")`:

```
foo      bar
1        x
2        y
         z
```

WDYT of this change? 