### PR TITLE
Add Sprint() func and test

### DIFF
--- a/table.go
+++ b/table.go
@@ -6,26 +6,27 @@
 //
 // Source: https://github.com/rodaine/table
 //
-//   table.DefaultHeaderFormatter = func(format string, vals ...interface{}) string {
-//     return strings.ToUpper(fmt.Sprintf(format, vals...))
-//   }
+//	table.DefaultHeaderFormatter = func(format string, vals ...interface{}) string {
+//	  return strings.ToUpper(fmt.Sprintf(format, vals...))
+//	}
 //
-//   tbl := table.New("ID", "Name", "Cost ($)")
+//	tbl := table.New("ID", "Name", "Cost ($)")
 //
-//   for _, widget := range Widgets {
-//     tbl.AddRow(widget.ID, widget.Name, widget.Cost)
-//   }
+//	for _, widget := range Widgets {
+//	  tbl.AddRow(widget.ID, widget.Name, widget.Cost)
+//	}
 //
-//   tbl.Print()
+//	tbl.Print()
 //
-//   // Output:
-//   // ID  NAME      COST ($)
-//   // 1   Foobar    1.23
-//   // 2   Fizzbuzz  4.56
-//   // 3   Gizmo     78.90
+//	// Output:
+//	// ID  NAME      COST ($)
+//	// 1   Foobar    1.23
+//	// 2   Fizzbuzz  4.56
+//	// 3   Gizmo     78.90
 package table
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -58,9 +59,9 @@ var (
 // column widths are calculated pre-formatting (though this issue can be mitigated
 // with increased padding).
 //
-//   tbl.WithHeaderFormatter(func(format string, vals ...interface{}) string {
-//     return strings.ToUpper(fmt.Sprintf(format, vals...))
-//   })
+//	tbl.WithHeaderFormatter(func(format string, vals ...interface{}) string {
+//	  return strings.ToUpper(fmt.Sprintf(format, vals...))
+//	})
 //
 // A good use case for formatters is to use ANSI escape codes to color the cells
 // for a nicer interface. The package color (https://github.com/fatih/color) makes
@@ -80,20 +81,20 @@ type WidthFunc func(string) int
 // header and first column, respectively. If nil is passed in (the default), no
 // formatting will be applied.
 //
-//   New("foo", "bar").WithFirstColumnFormatter(func(f string, v ...interface{}) string {
-//     return strings.ToUpper(fmt.Sprintf(f, v...))
-//   })
+//	New("foo", "bar").WithFirstColumnFormatter(func(f string, v ...interface{}) string {
+//	  return strings.ToUpper(fmt.Sprintf(f, v...))
+//	})
 //
 // WithPadding specifies the minimum padding between cells in a row and defaults
 // to DefaultPadding. Padding values less than or equal to zero apply no extra
 // padding between the columns.
 //
-//   New("foo", "bar").WithPadding(3)
+//	New("foo", "bar").WithPadding(3)
 //
 // WithWriter modifies the writer which Print outputs to, defaulting to DefaultWriter
 // when instantiated. If nil is passed, os.Stdout will be used.
 //
-//   New("foo", "bar").WithWriter(os.Stderr)
+//	New("foo", "bar").WithWriter(os.Stderr)
 //
 // WithWidthFunc sets the function used to calculate the width of the string in
 // a column. By default, the number of utf8 runes in the string is used.
@@ -105,12 +106,12 @@ type WidthFunc func(string) int
 // number of columns will be truncated. References to the data are not held, so
 // the passed in values can be modified without affecting the table's output.
 //
-//   New("foo", "bar").AddRow("fizz", "buzz").AddRow(time.Now()).AddRow(1, 2, 3).Print()
-//   // Output:
-//   // foo                              bar
-//   // fizz                             buzz
-//   // 2006-01-02 15:04:05.0 -0700 MST
-//   // 1                                2
+//	New("foo", "bar").AddRow("fizz", "buzz").AddRow(time.Now()).AddRow(1, 2, 3).Print()
+//	// Output:
+//	// foo                              bar
+//	// fizz                             buzz
+//	// 2006-01-02 15:04:05.0 -0700 MST
+//	// 1                                2
 //
 // Print writes the string representation of the table to the provided writer.
 // Print can be called multiple times, even after subsequent mutations of the
@@ -125,6 +126,7 @@ type Table interface {
 	AddRow(vals ...interface{}) Table
 	SetRows(rows [][]string) Table
 	Print()
+	Sprint() string
 }
 
 // New creates a Table instance with the specified header(s) provided. The number
@@ -224,6 +226,15 @@ func (t *table) SetRows(rows [][]string) Table {
 	}
 
 	return t
+}
+
+func (t *table) Sprint() string {
+	previousWriter := t.Writer
+	buf := new(bytes.Buffer)
+	t.WithWriter(buf).Print()
+	result := buf.String()
+	t.WithWriter(previousWriter)
+	return result
 }
 
 func (t *table) Print() {

--- a/table_test.go
+++ b/table_test.go
@@ -268,3 +268,17 @@ func TestTable_WithWidthFunc(t *testing.T) {
 	assert.Contains(t, actual, "请求 alpha")
 	assert.Contains(t, actual, "abc  beta")
 }
+
+func TestTable_Sprint(t *testing.T) {
+	t.Parallel()
+
+	tbl := New("foo", "bar").SetRows([][]string{
+		{"fizz", "buzz"},
+		{"lorem", "ipsum"},
+	})
+	tbl.WithWriter(os.Stderr)
+	// Verify output correct
+	assert.Equal(t, "foo    bar    \nfizz   buzz   \nlorem  ipsum  \n", tbl.Sprint())
+	// Verify Writer was restored correctly
+	assert.Equal(t, os.Stderr, tbl.(*table).Writer)
+}


### PR DESCRIPTION
Simple change to add a Sprint() function for when stdout is not your destination of choice.  A lot of the existing tests could be refactored to take advantage of this too.

Sorry about the whitespace changes; I'm a VS Code user and its Go mode automatically formats on save.  You can hide whitespace changes when you're reviewing.

Thanks for making this, it was *almost* exactly what I needed~