### PR TITLE
Allow for optional headers

### DIFF
--- a/table.go
+++ b/table.go
@@ -50,6 +50,9 @@ var (
 
 	// DefaultWidthFunc specifies the default WidthFunc for calculating column widths
 	DefaultWidthFunc WidthFunc = utf8.RuneCountInString
+
+	// DefaultPrintHeaders specifies if headers should be printed
+	DefaultPrintHeaders = true
 )
 
 // Formatter functions expose a fmt.Sprintf signature that can be used to modify
@@ -122,6 +125,7 @@ type Table interface {
 	WithWriter(w io.Writer) Table
 	WithWidthFunc(f WidthFunc) Table
 	WithHeaderSeparatorRow(r rune) Table
+	WithPrintHeaders(b bool) Table
 
 	AddRow(vals ...interface{}) Table
 	SetRows(rows [][]string) Table
@@ -139,6 +143,7 @@ func New(columnHeaders ...interface{}) Table {
 	t.WithHeaderFormatter(DefaultHeaderFormatter)
 	t.WithFirstColumnFormatter(DefaultFirstColumnFormatter)
 	t.WithWidthFunc(DefaultWidthFunc)
+	t.WithPrintHeaders(DefaultPrintHeaders)
 
 	for i, col := range columnHeaders {
 		t.header[i] = fmt.Sprint(col)
@@ -154,6 +159,7 @@ type table struct {
 	Writer               io.Writer
 	Width                WidthFunc
 	HeaderSeparatorRune  rune
+	PrintHeaders         bool
 
 	header []string
 	rows   [][]string
@@ -198,6 +204,11 @@ func (t *table) WithWidthFunc(f WidthFunc) Table {
 	return t
 }
 
+func (t *table) WithPrintHeaders(b bool) Table {
+	t.PrintHeaders = b
+	return t
+}
+
 func (t *table) AddRow(vals ...interface{}) Table {
 	maxNumNewlines := 0
 	for _, val := range vals {
@@ -237,10 +248,14 @@ func (t *table) Print() {
 	format := strings.Repeat("%s", len(t.header)) + "\n"
 	t.calculateWidths()
 
-	t.printHeader(format)
-	if t.HeaderSeparatorRune != 0 {
-		t.printHeaderSeparator(format)
-	}
+  if t.PrintHeaders {
+    t.printHeader(format)
+
+    if t.HeaderSeparatorRune != 0 {
+      t.printHeaderSeparator(format)
+    }
+  }
+
 	for _, row := range t.rows {
 		t.printRow(format, row)
 	}

--- a/table.go
+++ b/table.go
@@ -101,6 +101,10 @@ type WidthFunc func(string) int
 // WithWidthFunc sets the function used to calculate the width of the string in
 // a column. By default, the number of utf8 runes in the string is used.
 //
+// WithPrintHeaders specifies whether if the headers of the table should be
+// printed or not, which might be useful if the output is being piped to other
+// processes. By default, they are printed.
+//
 // AddRow adds another row of data to the table. Any values can be passed in and
 // will be output as its string representation as described in the fmt standard
 // package. Rows can have less cells than the total number of columns in the table;


### PR DESCRIPTION
This PR adds the flag `PrintHeaders` to the table struct that specifies whether headers should be printed or not.

This may be useful when output is being piped to other processes, where having a header is less desirable, and saves from doing a call to `head` (or `tail`) before processing.

Thank you for this wonderful library. Please let me know what you think about this, and if any more changes are necessary.