### PR TITLE
Add `WithHeaderSeparatorRow`

### DIFF
--- a/table.go
+++ b/table.go
@@ -248,12 +248,20 @@ func (t *table) Print() {
 
 func (t *table) printHeaderSeparator(format string) {
 	separators := make([]string, len(t.header))
-	separatorRuneWidth := t.Width(string([]rune{t.HeaderSeparatorRune}))
+
+	// The separator could be any unicode char. Since some chars take up more
+	// than one cell in a monospace context, we can get a number higher than 1
+	// here. Am example would be this emoji 🤣.
+	separatorCellWidth := t.Width(string([]rune{t.HeaderSeparatorRune}))
 	for index, headerName := range t.header {
-		headerRuneCount := t.Width(headerName)
-		separatorLen := headerRuneCount / separatorRuneWidth
-		separator := make([]rune, separatorLen)
-		for i := 0; i < separatorLen; i++ {
+		headerCellWidth := t.Width(headerName)
+		// Note that this might not be evenly divisble. In this case we'll get a
+		// separator that is at least 1 cell shorter than the header. This was
+		// an intentional design decision in order to prevent widening the cell
+		// or overstepping the column bounds.
+		repeatCharTimes := headerCellWidth / separatorCellWidth
+		separator := make([]rune, repeatCharTimes)
+		for i := 0; i < repeatCharTimes; i++ {
 			separator[i] = t.HeaderSeparatorRune
 		}
 		separators[index] = string(separator)

--- a/table_test.go
+++ b/table_test.go
@@ -176,6 +176,47 @@ bippity  boppity
 	}
 }
 
+func TestTable_WithHeaderSeparatorRow(t *testing.T) {
+	t.Parallel()
+
+	buf := bytes.Buffer{}
+	tbl := New("foo", "bar").WithHeaderSeparatorRow('-').WithWriter(&buf).AddRow("fizz", "buzz")
+
+	// Add some rows
+	tbl.AddRow()
+	tbl.AddRow("cat")
+
+	// add an entry that contains new lines
+	tbl.AddRow("bippity", "boppity\nboop")
+
+	// Add a couple more rows
+	tbl.AddRow("a", "b")
+	tbl.AddRow("c", "d")
+
+	// and another entry with more new lines
+	tbl.AddRow("1\n2", "x\ny\nz")
+
+	// check the full table
+	buf.Reset()
+	tbl.Print()
+	expected := `foo      bar      
+---      ---      
+fizz     buzz     
+                  
+cat               
+bippity  boppity  
+         boop     
+a        b        
+c        d        
+1        x        
+2        y        
+         z        
+`
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Fatalf("table mismatch (-expected +got):\n%s\nout=%#v", diff, buf.String())
+	}
+}
+
 func TestTable_AddRow_WithNewLines(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This function will print a separator line between the header and the data rows. It will use the same formatter as the header. The width of each separator cell will be equal to the width of the header cell in the same column. It supports runes, meaning dependning on the rune width, it might not be perfect.

Oh and, I use gofumpt, it reformatted some comments, hope that's okay.